### PR TITLE
Update PluginControl.cs adding support for UUI-generated record URLs

### DIFF
--- a/SimpleRecordCloner/SimpleRecordCloner/PluginControl.cs
+++ b/SimpleRecordCloner/SimpleRecordCloner/PluginControl.cs
@@ -222,9 +222,14 @@ namespace martintmg.MSDYN.Tools.SimpleRecordCloner
                     current++;
                     var paramaters = GetParameterFromURL(recordUrl.ToString());
 
-                    int objectTypeCode = int.Parse(GetParameter(paramaters, "etc").ToString());
                     var RecordId = new Guid(GetParameter(paramaters, "id").ToString());
-                    var logicalName = GetEntityLogicalNameFromMetadataByObjectTypeCode(objectTypeCode);
+                    var logicalName = GetParameter(paramaters, "etn")?.ToString();
+                    if (logicalName == null)
+                    {
+                        // fallback if the URL was generated through an oder Dynamics version
+                        int objectTypeCode = int.Parse(GetParameter(paramaters, "etc").ToString());
+                        logicalName = GetEntityLogicalNameFromMetadataByObjectTypeCode(objectTypeCode);
+                    }
 
                     var entity = service.Retrieve(logicalName, RecordId, new ColumnSet(true));
 


### PR DESCRIPTION
Dynamics UUI generates URLs which already contain the logical entity name as parameter etn but unfortunately no longer contain the entity type code. This adoption ensures that parameter etn is checked first and uses parameter etc only if the entity's logical name is not available.